### PR TITLE
nvic dependency fixes

### DIFF
--- a/soc/st/arm/Systick.hpp
+++ b/soc/st/arm/Systick.hpp
@@ -11,8 +11,8 @@
 #include <utility>
 
 // xmcu
-#include <soc/st/arm/IRQ_config.hpp>
 #include <soc/peripheral.hpp>
+#include <soc/st/arm/IRQ_config.hpp>
 #include <xmcu/Non_copyable.hpp>
 #include <xmcu/bit.hpp>
 #include <xmcu/config.hpp>

--- a/soc/st/arm/m0/nvic.hpp
+++ b/soc/st/arm/m0/nvic.hpp
@@ -6,7 +6,7 @@
  */
 
 // externals
-#include <stm32l0xx.h>
+#include <core_cm0plus.h>
 
 // xmcu
 #include <xmcu/Non_copyable.hpp>

--- a/soc/st/arm/m4/nvic.hpp
+++ b/soc/st/arm/m4/nvic.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 
 // externals
-#include <stm32wbxx.h>
+#include <core_cm4.h>
 
 // xmcu
 #include <soc/Scoped_guard.hpp>


### PR DESCRIPTION
nvic.hpp is no longer dependent on a specific mcu 